### PR TITLE
Allow PHP 8.2 and higher

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -7,7 +7,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php-versions: [ '8.0', '8.1' ]
+        php-versions: [ '8.0', '8.1', '8.2' ]
     name: 'PHPUnit [PHP ${{ matrix.php-versions }}]'
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
       }
    },
    "require": {
-      "php": "8.0.* || 8.1.*",
+      "php": "^8.0",
       "ext-curl": "*",
       "ext-openssl": "*",
       "ext-simplexml": "*",


### PR DESCRIPTION
I think it's best to allow `^8.0` and treat incompatibilities to newer versions as bugs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
